### PR TITLE
Feat: write yaml handler

### DIFF
--- a/URL_Shortener/main.go
+++ b/URL_Shortener/main.go
@@ -15,12 +15,6 @@ func main() {
   url: https://github.com/gophercises/urlshort/tree/solution
 `
 
-	data, err := urlshort.ParseYAML([]byte(yaml))
-	if err != nil {
-		fmt.Println("ERROR: ", err)
-	}
-	fmt.Println(data)
-
 	fmt.Println("Hello, world")
 
 	pathsToUrls := map[string]string{

--- a/URL_Shortener/main.go
+++ b/URL_Shortener/main.go
@@ -8,6 +8,19 @@ import (
 
 func main() {
 
+	yaml := `
+- path: /urlshort
+  url: https://github.com/gophercises/urlshort
+- path: /urlshort-final
+  url: https://github.com/gophercises/urlshort/tree/solution
+`
+
+	data, err := urlshort.ParseYAML([]byte(yaml))
+	if err != nil {
+		fmt.Println("ERROR: ", err)
+	}
+	fmt.Println(data)
+
 	fmt.Println("Hello, world")
 
 	pathsToUrls := map[string]string{

--- a/URL_Shortener/main.go
+++ b/URL_Shortener/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"url_shortener/urlshort"
 )
@@ -14,8 +13,6 @@ func main() {
 - path: /urlshort-final
   url: https://github.com/gophercises/urlshort/tree/solution
 `
-
-	fmt.Println("Hello, world")
 
 	pathsToUrls := map[string]string{
 		"/dog": "www.samplesite.com/article-on-dogs",

--- a/URL_Shortener/urlshort/handler.go
+++ b/URL_Shortener/urlshort/handler.go
@@ -1,15 +1,22 @@
 package urlshort
 
 import (
+	"fmt"
 	"net/http"
+
+	"gopkg.in/yaml.v3"
 )
+
+type PathURL struct {
+	Path string `yaml:"path"`
+	URL  string `yaml:"url"`
+}
 
 // MapHandler is a function that's called whenever the server receives a request.
 // The MapHandler is a closure; it has access to request details (http.Request).
 // It extracts the URL from this request and checks if it's in the map; if it is,
 // it redirects to corresponding URL; if not, it will fallback to fallback handler.
 func MapHandler(pathsToUrls map[string]string, fallback http.Handler) http.HandlerFunc {
-
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		// Extract URL from request
@@ -21,4 +28,18 @@ func MapHandler(pathsToUrls map[string]string, fallback http.Handler) http.Handl
 		}
 		fallback.ServeHTTP(w, r)
 	}
+}
+
+func YAMLHandler(yml []byte, fallback http.Handler) (http.HandlerFunc, error) {
+
+	return nil, nil
+}
+
+func ParseYAML(yml []byte) ([]PathURL, error) {
+	var yamlData []PathURL
+	err := yaml.Unmarshal(yml, &yamlData)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unmarshal YAML data: %v", err)
+	}
+	return yamlData, nil
 }

--- a/URL_Shortener/urlshort/handler.go
+++ b/URL_Shortener/urlshort/handler.go
@@ -47,6 +47,7 @@ func YAMLHandler(yml []byte, fallback http.Handler) (http.HandlerFunc, error) {
 	}, nil
 }
 
+// Helper function: unmarshals YAML data into a struct slice
 func parseYAML(yml []byte) ([]PathURL, error) {
 	var yamlData []PathURL
 	err := yaml.Unmarshal(yml, &yamlData)
@@ -56,6 +57,7 @@ func parseYAML(yml []byte) ([]PathURL, error) {
 	return yamlData, nil
 }
 
+// Helpre function: builds a map of paths and URLs from a struct slice
 func buildURLMap(parsedYAML []PathURL) map[string]string {
 	pathsToURLS := make(map[string]string)
 

--- a/URL_Shortener/urlshort/handler.go
+++ b/URL_Shortener/urlshort/handler.go
@@ -36,15 +36,7 @@ func YAMLHandler(yml []byte, fallback http.Handler) (http.HandlerFunc, error) {
 		return nil, err
 	}
 	mappedData := buildURLMap(parsedData)
-
-	return func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-		if dest, ok := mappedData[path]; ok {
-			http.Redirect(w, r, dest, http.StatusFound)
-			return
-		}
-		fallback.ServeHTTP(w, r)
-	}, nil
+	return MapHandler(mappedData, fallback), nil
 }
 
 // Helper function: unmarshals YAML data into a struct slice
@@ -61,8 +53,7 @@ func parseYAML(yml []byte) ([]PathURL, error) {
 func buildURLMap(parsedYAML []PathURL) map[string]string {
 	pathsToURLS := make(map[string]string)
 
-	// Iterate over the slice of PathURL and populate map
-	// Ignore the index; unpack the struct data
+	// Iterate over the slice of PathURL and populate map with path: url
 	for _, pathURL := range parsedYAML {
 		pathsToURLS[pathURL.Path] = pathURL.URL
 	}


### PR DESCRIPTION
Write a handler that can parse YAMLs, composed of a path and a URL, populate a map, and then use the `MapHander()` as a fallback.